### PR TITLE
rake task visible to rails app

### DIFF
--- a/lib/haml-rails.rb
+++ b/lib/haml-rails.rb
@@ -54,6 +54,10 @@ module Haml
           end
         end
       end
+
+      rake_tasks do
+        load 'tasks/erb2haml.rake'
+      end  
     end
   end
 end

--- a/lib/tasks/erb2haml.rake
+++ b/lib/tasks/erb2haml.rake
@@ -1,7 +1,7 @@
 namespace :haml do
+  
+  desc 'Convert html.erb to html.haml each file in app/views'
   task :erb_2_haml do
-
-    puts "This task will generate a .html.haml translation of each of the  .html.erb files in app/views and its subdirectories."
 
     erb_files = Dir.glob('app/views/**/*.erb').select { |f| File.file? f}
     haml_files = Dir.glob('app/views/**/*.haml').select { |f| File.file? f}


### PR DESCRIPTION
1 )Now, in rails 4.2 app when i run ```rake -T``` , I dont' see ```haml:erb_2_haml``` rake task , so fix it. 
2)Add more concise desc for task(It is needed for normal display in rake -T)