### PR TITLE
update appraisal to 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ rvm:
 gemfile:
   - gemfiles/rails_4_0.gemfile
   - gemfiles/rails_4_1.gemfile
+  - gemfiles/rails_4_2.gemfile
 matrix:
   exclude:
     - rvm: 1.9.3
       gemfile: gemfiles/rails_4_1.gemfile
+script: "bundle exec rake test"

--- a/Appraisals
+++ b/Appraisals
@@ -1,13 +1,11 @@
 appraise "rails_4_0" do
   gem "rails", "~> 4.0.1"
-
-  gem 'rubysl', '~> 2.0', platforms: :rbx
-  gem 'minitest', platforms: :rbx
 end
 
 appraise "rails_4_1" do
-  gem "rails", "4.1.0.beta1"
+  gem "rails", "4.1"
+end
 
-  gem 'rubysl', '~> 2.0', platforms: :rbx
-  gem 'minitest', platforms: :rbx
+appraise "rails_4_2" do
+  gem "rails", "4.2"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,6 @@
+require 'rubygems'
 require 'bundler'
 Bundler::GemHelper.install_tasks
-
-begin
-  require 'appraisal'
-rescue LoadError
-end
 
 require 'rake/testtask'
 Rake::TestTask.new(:test) do |test|

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -2,9 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "rails", "4.1.0.beta1"
+gem "rubysl", "~> 2.0", :platforms => :rbx
+gem "minitest", :platforms => :rbx
+gem "html2haml"
+gem "rails", "4.1"
 
-gem 'rubysl', '~> 2.0', platforms: :rbx
-gem 'minitest', platforms: :rbx
-
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -5,6 +5,6 @@ source "https://rubygems.org"
 gem "rubysl", "~> 2.0", :platforms => :rbx
 gem "minitest", :platforms => :rbx
 gem "html2haml"
-gem "rails", "~> 4.0.1"
+gem "rails", "4.2"
 
 gemspec :path => "../"

--- a/haml-rails.gemspec
+++ b/haml-rails.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rails",   [">= 4.0.1"]
   s.add_development_dependency "bundler", "~> 1.2"
   s.add_development_dependency "rake"
-  s.add_development_dependency 'appraisal', '>= 0.3.8'
+  s.add_development_dependency 'appraisal', '~> 1.0'
 
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files`.split("\n").select{|f| f =~ /^bin/}


### PR DESCRIPTION
Appraisal gem is old, so update it.
1) appraisal tasks, defined in rake files are deprecated
```
$ rake -T
rake appraisal            # Run the given task for all appraisals
rake appraisal:cleanup    # DEPRECATED: Remove all generated gemfiles from gemfiles/ folder
rake appraisal:gemfiles   # DEPRECATED: Generate a Gemfile for each appraisal
rake appraisal:install    # DEPRECATED: Resolve and install dependencies for each appraisal
rake appraisal:rails_4_0  # DEPRECATED: Run the given task for appraisal rails_4_0
rake appraisal:rails_4_1  # DEPRECATED: Run the given task for appraisal rails_4_1

```
2) Define this the same dependencies in Appraisals is not needed, see appraisals readme:
```
The dependencies in your Appraisals file are combined with dependencies in your Gemfile, so you don't need to repeat anything that's the same for each appraisal. If something is specified in both the Gemfile and an appraisal, the version from the appraisal takes precedence.
```
3) Add rails 4.2 to appraisal
