### PR TITLE
refactoring tests

### DIFF
--- a/test/lib/generators/haml/controller_generator_test.rb
+++ b/test/lib/generators/haml/controller_generator_test.rb
@@ -2,16 +2,17 @@ require 'test_helper'
 require 'lib/generators/haml/testing_helper'
 
 class Haml::Generators::ControllerGeneratorTest < Rails::Generators::TestCase
-  destination File.join(Rails.root)
+  destination Rails.root
   tests Rails::Generators::ControllerGenerator
-  arguments %w(Account foo bar --template-engine haml)
 
   setup :prepare_destination
   setup :copy_routes
 
-  test "should invoke template engine" do
-    run_generator
-    assert_file "app/views/account/foo.html.haml", %r(app/views/account/foo\.html\.haml)
-    assert_file "app/views/account/bar.html.haml", %r(app/views/account/bar\.html\.haml)
-  end
+  arguments %w(Account foo bar --template-engine haml)
+
+  test "should invoke haml engine" do
+    run_generator 
+    assert_file "app/views/account/foo.html.haml"
+    assert_file "app/views/account/bar.html.haml"
+  end 
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,26 +7,24 @@ require 'rails/generators/test_case'
 class TestApp < Rails::Application
   config.root = File.dirname(__FILE__)
 end
-Rails.application = TestApp
 
 module Rails
   def self.root
     @root ||= File.expand_path(File.join(File.dirname(__FILE__), '..', 'tmp', 'rails'))
   end
 end
-Rails.application.config.root = Rails.root
 
 # Call configure to load the settings from
 # Rails.application.config.generators to Rails::Generators
-Rails::Generators.configure! Rails.application.config.generators
+Rails.application.load_generators
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
 def copy_routes
-  routes = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures', 'routes.rb'))
+  routes = File.join(File.dirname(__FILE__), 'fixtures', 'routes.rb')
   destination = File.join(Rails.root, "config")
   FileUtils.mkdir_p(destination)
-  FileUtils.cp File.expand_path(routes), destination
+  FileUtils.cp File.expand_path(routes), File.expand_path(destination)
 end
 
 # Asserts the given class exists in the given content. When a block is given,


### PR DESCRIPTION
1)
 ```ruby 
File.join(Rails.root) == Rails.root
```
2) I think we don't need regexp for ```assert_file``` , we only must simply test, that haml file exists.
See docs for asset_file [here](https://github.com/rails/rails/blob/390449ab8c55dacc08517bc270c6203bb1f50e02/railties/lib/rails/generators/testing/assertions.rb#L7)
3) ```Rails.application.config.root = Rails.root ```
is not needed, because we set in ```TestApp``` config , and TestApp sets as Rails.application([docs](http://api.rubyonrails.org/classes/Rails/Application.html) , Multiple Application section)
4) Use ```Rails.application.load_generators``` as a more simple solution
//cc @indirect 