### PR TITLE
Removing whitespace in the scaffold template generator

### DIFF
--- a/lib/generators/haml/scaffold/templates/index.html.haml
+++ b/lib/generators/haml/scaffold/templates/index.html.haml
@@ -9,7 +9,7 @@
       %th
       %th
       %th
-      
+
   %tbody
     - @<%= plural_table_name %>.each do |<%= singular_table_name %>|
       %tr


### PR DESCRIPTION
This whitespace, introduced at 6633f1975b5767e06ed22e84b8684b7ec13df8a4, would cause Git warning when committing the generated files into the repository.