### PR TITLE
Revert "Restore ruby 1.8 compatibility"

### DIFF
--- a/lib/generators/haml/scaffold/templates/index.html.haml
+++ b/lib/generators/haml/scaffold/templates/index.html.haml
@@ -18,7 +18,7 @@
 <% end -%>
         %td= link_to 'Show', <%= singular_table_name %>
         %td= link_to 'Edit', edit_<%= singular_table_name %>_path(<%= singular_table_name %>)
-        %td= link_to 'Destroy', <%= singular_table_name %>, :method => :delete, :data => { :confirm => 'Are you sure?' }
+        %td= link_to 'Destroy', <%= singular_table_name %>, method: :delete, data: { confirm: 'Are you sure?' }
 
 %br
 


### PR DESCRIPTION
Now that Ruby :one:.:eight: support has been dropped since #90, it's time to generate the templates with the new Hash syntax. :wink: