### PR TITLE
[bug #102] fix erb to haml conversion fails with spaces in the path

### DIFF
--- a/lib/rails/generators/haml/application_layout/application_layout_generator.rb
+++ b/lib/rails/generators/haml/application_layout/application_layout_generator.rb
@@ -1,20 +1,24 @@
 require 'rails'
+require 'shellwords'
 
 module Haml
   module Generators
     class ApplicationLayoutGenerator < ::Rails::Generators::Base
 
+      HTML_LAYOUT_PATH = 'app/views/layouts/application.html.erb'
+      HAML_LAYOUT_PATH = 'app/views/layouts/application.html.haml'
+
       # Converts existing application.html.erb to haml format,
       # and creates app/views/layouts/application.html.haml
       # with some error checking.
       def convert
-        app_layout_from = ::Rails.root.join('app/views/layouts/application.html.erb')
-        app_layout_to   = ::Rails.root.join('app/views/layouts/application.html.haml')
+        app_layout_from = ::Rails.root.join(HTML_LAYOUT_PATH).to_s
+        app_layout_to   = ::Rails.root.join(HAML_LAYOUT_PATH).to_s
 
         if File.exist?(app_layout_from)
 
           if !File.exist?(app_layout_to)
-            `html2haml #{app_layout_from} #{app_layout_to}`
+            `html2haml #{app_layout_from.shellescape} #{app_layout_to.shellescape}`
             puts "Success! app/views/layouts/application.html.haml is created.\n" \
                  "Please remove the erb file: app/views/layouts/application.html.erb"
           else


### PR DESCRIPTION
https://github.com/indirect/haml-rails/issues/102
Now rails generate haml:application_layout convert doesn't fail even if the file path has spaces.