### PR TITLE
Update html2haml dependency.

### DIFF
--- a/haml-rails.gemspec
+++ b/haml-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", [">= 4.0.1"]
   s.add_dependency "actionpack",    [">= 4.0.1"]
   s.add_dependency "railties",      [">= 4.0.1"]
-  s.add_dependency "html2haml",     [">= 1.0.1"]
+  s.add_dependency "html2haml",     [">= 2.0.0"]
 
   s.add_development_dependency "rails",   [">= 4.0.1"]
   s.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
html2haml `2.0.0` was released on January 19th 2015. I propose we upgrade this dependency.

https://rubygems.org/gems/html2haml