### PR TITLE
Use Rails 5 default mailer layout template

### DIFF
--- a/lib/generators/haml/mailer/templates/layout.html.haml
+++ b/lib/generators/haml/mailer/templates/layout.html.haml
@@ -1,3 +1,8 @@
+!!!
 %html
+  %head
+    %meta{:content => "text/html; charset=utf-8", "http-equiv" => "Content-Type"}/
+    :css
+      /* Email styles need to be inline */
   %body
     = yield


### PR DESCRIPTION
Hi André, hope you are doing great 😃 

My original intention for this PR was the _hmtl_ typo in the mailer layout - but that has been fixed already.

Now I propose to go one step further and use Rails 5 default mailer layout, instead of overwriting it with the 3 basic lines used by the current generator.

I would argue that including the meta tag is good practice and the hint to inline CSS can potentially save some developer a headache.
## 

I forgot to mention, that while the tests are passing, I do get this warning (for line 18 and 5 others):

`/mailer_generator_test.rb:18: warning: ambiguous first argument; put parentheses or a space even after '/' operator`

I am not sure how you want to deal with this, as line 4 of the changed template is actually valid haml that ends the void tag with a `/`.
