### PR TITLE
Allow Haml 5.0.0

### DIFF
--- a/haml-rails.gemspec
+++ b/haml-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "haml-rails"
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "haml",          [">= 4.0.6", "< 5.0"]
+  s.add_dependency "haml",          [">= 4.0.6", "< 6.0"]
   s.add_dependency "activesupport", [">= 4.0.1"]
   s.add_dependency "actionpack",    [">= 4.0.1"]
   s.add_dependency "railties",      [">= 4.0.1"]


### PR DESCRIPTION
Haml 5.0.0.beta.2 has been [out for a while][1] and it packs some 
interesting fixes that can't be tested until haml-rails allows for it.

[1]: https://rubygems.org/gems/haml/versions/5.0.0.beta.2