### PR TITLE
Fix "Rails::SourceAnnotationExtractor is not a class/module" in Rails 6

### DIFF
--- a/lib/haml-rails.rb
+++ b/lib/haml-rails.rb
@@ -46,7 +46,13 @@ module Haml
       # provided directly by railties 3.2..4.1 but was dropped in 4.2.
       if Gem::Requirement.new(">= 4.2").satisfied_by?(Gem::Version.new(::Rails.version))
         initializer 'haml_rails.configure_source_annotation' do
-          SourceAnnotationExtractor::Annotation.register_extensions('haml') do |tag|
+          annotation_class = if ::Rails::VERSION::STRING >= '6.0'
+                               ::Rails::SourceAnnotationExtractor::Annotation
+                             else
+                               SourceAnnotationExtractor::Annotation
+                             end
+
+          annotation_class.register_extensions('haml') do |tag|
             /\s*-#\s*(#{tag}):?\s*(.*)/
           end
         end


### PR DESCRIPTION
When using gem with Rails 6, error `Rails::SourceAnnotationExtractor is not a class/module (TypeError)` raise on startup.
PR fixes it.