### PR TITLE
Lower required_rubygems_version to 2

### DIFF
--- a/haml-rails.gemspec
+++ b/haml-rails.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.licenses    = ["MIT"]
 
   s.rubyforge_project         = "haml-rails"
-  s.required_rubygems_version = ">= 3.0.0"
+  s.required_rubygems_version = ">= 2.0.0"
   s.required_ruby_version     = ">= 2.3.0"
 
   s.add_dependency "haml",          [">= 4.0.6", "< 6.0"]


### PR DESCRIPTION
Heroku, AWS Beanstalk, and others dont have rubygems 3 yet (#153). 